### PR TITLE
Support for gopher-write

### DIFF
--- a/AUTHORS.org
+++ b/AUTHORS.org
@@ -22,3 +22,4 @@ supplementary information you'd care to share below.
 
   - [[https://github.com/kensanata/gopher.el][kensanata's repository]]
   - non-standard ports
+  - item type w (writing to gopher)


### PR DESCRIPTION
Would you be interested in adding support for a non-standard item type? I've been thinking about adding support to a *write* item type which would allow me to post more content than just a query string. As a proof of concept, I wrote a Gopher Server front-end to my wiki, which allows me to post to it.
There's some background and examples using netcat on my [Gopher Wiki](https://alexschroeder.ch/wiki/2017-12-30_Gopher_Wiki) blog post. I noticed that Charles Childers seemed [interested](https://octodon.social/web/statuses/99281693338830753) at the time; he's the author of an iOS Gopher client.