### PR TITLE
Stop when navigating past the last item.

### DIFF
--- a/gopher.el
+++ b/gopher.el
@@ -384,10 +384,14 @@ Unreliable, e.g. foo.com:70/1/bar becomes foo.com:70/1/, which is useless."
 With optional argument REVERSE, move the cursor to the previous line instead."
     `(defun ,(intern (concat "gopher-" (symbol-name (if reverse 'previous 'next)) "-" (symbol-name content-type))) ()
        (interactive)
-       (if ,reverse (forward-line -1) (forward-line))
+       (forward-line ,(if reverse -1 1))
        (move-beginning-of-line nil)
-       (while (not (eq ',content-type (gopher-get-content-type (text-properties-at (point)))))
-	 (if ,reverse (forward-line -1) (forward-line)))))
+       (while (and (not (= (line-number-at-pos)
+                           (line-number-at-pos ,(if reverse
+                                                    `(point-min)
+                                                  `(point-max)))))
+                   (not (eq ',content-type (gopher-get-content-type (text-properties-at (point))))))
+         (forward-line ,(if reverse -1 1)))))
 
 (defun gopher-history-current-item (n &optional do-not-move)
   "Rotate the gopher history by N places, and then return that item.


### PR DESCRIPTION
When navigating forward past the last item, or backward past the first item, the code enters an infinite loop (that can be cancelled by pressing C-g). This prevents the infinite loop from occurring.