### PR TITLE
Add missing package dependencies

### DIFF
--- a/gopher.el
+++ b/gopher.el
@@ -19,6 +19,7 @@
 ;;         and the gopher.el authors (see AUTHORS.org)
 ;; URL: http://github.com/ardekantur/gopher.el
 ;; Package-Version: 20190211.1742
+;; Package-Requires: ((emacs "24.4") (w3m "0"))
 ;; Version: 0.0.2
 
 ;; This file is not part of GNU Emacs.


### PR DESCRIPTION
Emacs 24.4 is required for shr, and it also provides cl-lib. w3m is only package in MELPA, so we use a catch-all zero dependency version number for that.

See https://github.com/melpa/melpa/pull/6021